### PR TITLE
Fix #1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,6 +28,12 @@
         "size": 32
     }],
     "default_title": "Click to disable First Party Isolation"
+  },
+  
+  "applications": {
+    "gecko": {
+      "strict_min_version": "58.0a1"
+    }
   }
 
 }


### PR DESCRIPTION
As stated from those pages ([applications manifest key](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/applications) & [valid application versions](https://addons.mozilla.org/en-US/firefox/pages/appversions/)), the extension indicates that the user must have at least Firefox 58.0a1.